### PR TITLE
QEWD-27 Feature/jasmine testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+before_script:
+  - npm install
+
+script: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rippleosi-ewd3
 
+[![Build Status](https://travis-ci.org/chrisjohnson1988/Qewd-Ripple.svg?branch=master)](https://travis-ci.org/chrisjohnson1988/Qewd-Ripple)
+
 Email: <code.custodian@rippleosi.org>
 2016 Ripple Foundation Community Interest Company [http://rippleosi.org  ](http://rippleosi.org)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # rippleosi-ewd3
 
-[![Build Status](https://travis-ci.org/chrisjohnson1988/Qewd-Ripple.svg?branch=master)](https://travis-ci.org/chrisjohnson1988/Qewd-Ripple)
+[![Build Status](https://travis-ci.org/RippleOSI/Qewd-Ripple.svg?branch=master)](https://travis-ci.org//RippleOSI/Qewd-Ripple)
+
 
 Email: <code.custodian@rippleosi.org>
 2016 Ripple Foundation Community Interest Company [http://rippleosi.org  ](http://rippleosi.org)

--- a/lib/headings/mdtreports.aql
+++ b/lib/headings/mdtreports.aql
@@ -1,19 +1,18 @@
-select
-  a/uid/value as uid,
-  a/context/start_time/value as date_created,
-  b_d/activities[at0001]/timing/value as meeting_date,
-  b_d/protocol[at0008]/items[at0011]/value/value as service_team,
-  b_f/data[at0001]/items[at0002]/value/value as notes,
-  b_g/data[at0001]/items[at0004]/value/value as question
- from EHR e
- contains COMPOSITION a[openEHR-EHR-COMPOSITION.report.v1]
- contains (
-   INSTRUCTION b_d[openEHR-EHR-INSTRUCTION.request-referral.v1] or
-   EVALUATION b_f[openEHR-EHR-EVALUATION.recommendation.v1] or
-   EVALUATION b_g[openEHR-EHR-EVALUATION.reason_for_encounter.v1]
- )
- where
-   a/name/value='MDT Output Report' and (
-     e/ehr_status/subject/external_ref/namespace='uk.nhs.nhs_number' and
-     e/ehr_status/subject/external_ref/id/value='{{patientId}}'
-   )
+select     
+  a/uid/value as uid,     
+  a/context/start_time/value as meeting_date,
+  a/content[openEHR-EHR-SECTION.referral_details_rcp.v1]/items[openEHR-EHR-ACTION.referral_uk.v1]/time/value as request_date,
+  a_a/protocol[at0008]/items[at0011]/value/value as service_team,
+  a_b/data[at0001]/items[at0004]/value/value as question,
+  a_c/data[at0001]/items[at0002]/value/value as notes, 
+  a/content[openEHR-EHR-SECTION.referral_details_rcp.v1]/items[openEHR-EHR-ACTION.referral_uk.v1]/ism_transition/careflow_step/defining_code/code_string as careflow_step
+from EHR e [ehr_id/value = '{{ehrId}}']
+contains COMPOSITION a[openEHR-EHR-COMPOSITION.report.v1]
+contains ( 
+ INSTRUCTION a_a[openEHR-EHR-INSTRUCTION.request.v0] or
+ EVALUATION a_b[openEHR-EHR-EVALUATION.reason_for_encounter.v1] or
+ EVALUATION a_c[openEHR-EHR-EVALUATION.recommendation.v1])
+where 
+  a/name/value='MDT Output Report' and 
+  a/content[openEHR-EHR-SECTION.referral_details_rcp.v1]/items[openEHR-EHR-ACTION.referral_uk.v1]/ism_transition/careflow_step/defining_code/code_string = 'at0002'
+

--- a/lib/headings/procedures.aql
+++ b/lib/headings/procedures.aql
@@ -14,4 +14,4 @@ select
  contains ACTION b_a[openEHR-EHR-ACTION.procedure.v1]
  where a/name/value='Procedures list'
  and e/ehr_status/subject/external_ref/namespace = 'uk.nhs.nhs_number'
- and e/ehr_status/subject/external_ref/id/value = '{{patientid}}'
+ and e/ehr_status/subject/external_ref/id/value = '{{patientId}}'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "EWD 3/ ewd-xpress Middle Tier for Ripple OSI",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node_modules/jasmine/bin/jasmine.js"
   },
   "dependencies": {
     "ewd-xpress": "",
@@ -15,6 +15,9 @@
     "mysql": "",
     "passport": "",
     "passport-auth0": ""
+  },
+  "devDependencies": {
+    "jasmine": ""
   },
   "repository": {
     "type": "git",

--- a/spec/headings_spec.js
+++ b/spec/headings_spec.js
@@ -29,14 +29,14 @@ Object.keys(openEHR.servers).forEach(function(server) {
   }
 
   describe("OpenEHR Server " + server, function() {
-    var ivonCoxNhsId = 9999999000;
-    var ivonCoxEhrId;
+    var ivorCoxNhsId = 9999999000;
+    var ivorCoxEhrId;
 
     beforeEach(function(done) {
       request('/rest/v1/ehr', {
-          subjectId: ivonCoxNhsId,
+          subjectId: ivorCoxNhsId,
           subjectNamespace: 'uk.nhs.nhs_number'
-        }, done, function(res) { ivonCoxEhrId = res.ehrId;}
+        }, done, function(res) { ivorCoxEhrId = res.ehrId;}
       );
     });
 
@@ -45,9 +45,9 @@ Object.keys(openEHR.servers).forEach(function(server) {
       var heading = headings.headings[headingName];
       describe("using " + headingName, function() {
         if(heading.query && heading.query.aql) {
-          it("can get Ivon Cox details using AQL", function(done) {
+          it("can get Ivor Cox details using AQL", function(done) {
             aql = template.replace(heading.query.aql,{
-              patientId: ivonCoxNhsId, ehrId: ivonCoxEhrId
+              patientId: ivorCoxNhsId, ehrId: ivorCoxEhrId
             });
 
             request('/rest/v1/query', {aql:aql}, done, function(res) {

--- a/spec/headings_spec.js
+++ b/spec/headings_spec.js
@@ -1,0 +1,61 @@
+var headings = require('./../lib/headings/headings');
+var openEHR = require('./../lib/openEHR/openEHR');
+var template = require('./../lib/template');
+
+Object.keys(openEHR.servers).forEach(function(server) {
+  var session;
+
+  // Create a session with the current openEHR server
+  beforeEach(function(done) {
+    openEHR.startSession(server, function(res) {
+      session = res.id;
+      done();
+    });
+  });
+
+  afterEach(function(done) {
+    openEHR.stopSession(server, session, done);
+  });
+
+  function request(url, data, done, process) {
+    openEHR.request({
+      url: url,
+      queryString: data,
+      host: server,
+      session: session,
+      processBody: process,
+      callback: done
+    });
+  }
+
+  describe("OpenEHR Server " + server, function() {
+    var ivonCoxNhsId = 9999999000;
+    var ivonCoxEhrId;
+
+    beforeEach(function(done) {
+      request('/rest/v1/ehr', {
+          subjectId: ivonCoxNhsId,
+          subjectNamespace: 'uk.nhs.nhs_number'
+        }, done, function(res) { ivonCoxEhrId = res.ehrId;}
+      );
+    });
+
+    // For each heading which has an aql defined
+    Object.keys(headings.headings).forEach(function(headingName) {
+      var heading = headings.headings[headingName];
+      describe("using " + headingName, function() {
+        if(heading.query && heading.query.aql) {
+          it("can get Ivon Cox details using AQL", function(done) {
+            aql = template.replace(heading.query.aql,{
+              patientId: ivonCoxNhsId, ehrId: ivonCoxEhrId
+            });
+
+            request('/rest/v1/query', {aql:aql}, done, function(res) {
+              expect(res.resultSet).toBeTruthy();
+            });
+          });
+        }
+      });
+    });
+  });
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
# Introduction

This pull request introduces a level of jasmine testing into the project which (currently) validates the aql statements execute and return a value against each of the backend servers for the test user `Ivor Cox`.

The testing has been implemented as QEWD-27 identified that there is an issue with the `mdtreport` when used against EtherCIS. This has been proven using the test suite which fails in the scenario.

# Sneaky Fix

The test suite has also identified a typo in `lib/headings/procedures.aql`. This has been corrected.

# Travis CI

I have added the corresponding `.travis-ci.yml` file such that the test suite will automatically run on commit. This will need to be enabled on the main repository, but can be seen in action on my branch.