### PR TITLE
Field mapping test

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "js2xmlparser": ""
   },
   "devDependencies": {
-    "jasmine": ""
+    "jasmine": "",
+    "underscore": ""
   },
   "repository": {
     "type": "git",

--- a/spec/headings_spec.js
+++ b/spec/headings_spec.js
@@ -43,7 +43,7 @@ inOpenEHRSession(function(request, server) {
     var ivorCoxNhsId = 9999999000;
     var ivorCoxEhrId;
 
-    beforeEach(function(done) {
+    beforeAll(function(done) {
       request('/rest/v1/ehr', {
           subjectId: ivorCoxNhsId,
           subjectNamespace: 'uk.nhs.nhs_number'
@@ -55,7 +55,7 @@ inOpenEHRSession(function(request, server) {
     forEachHeading(function(heading) {
       describe("GET AQL response of " + heading.name, function() {
         var result;
-        beforeEach(function(done){
+        beforeAll(function(done){
           spyOn(dateTime, 'getRippleTime');
           spyOn(dateTime, 'msSinceMidnight');
           var aql = template.replace(heading.query.aql,{

--- a/spec/helpers/session.js
+++ b/spec/helpers/session.js
@@ -1,0 +1,64 @@
+/*
+
+ ----------------------------------------------------------------------------
+ | qewd-ripple: QEWD-based Middle Tier for Ripple OSI                       |
+ |                                                                          |
+ | Copyright (c) 2016-17 Ripple Foundation Community Interest Company       |
+ | All rights reserved.                                                     |
+ |                                                                          |
+ | http://rippleosi.org                                                     |
+ | Email: code.custodian@rippleosi.org                                      |
+ |                                                                          |
+ | Author: Chris Johnson                                                    |
+ |                                                                          |
+ | Licensed under the Apache License, Version 2.0 (the "License");          |
+ | you may not use this file except in compliance with the License.         |
+ | You may obtain a copy of the License at                                  |
+ |                                                                          |
+ |     http://www.apache.org/licenses/LICENSE-2.0                           |
+ |                                                                          |
+ | Unless required by applicable law or agreed to in writing, software      |
+ | distributed under the License is distributed on an "AS IS" BASIS,        |
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. |
+ | See the License for the specific language governing permissions and      |
+ |  limitations under the License.                                          |
+ ----------------------------------------------------------------------------
+
+  27 January 2017
+
+  Define a jasmine helper which wraps a test suite and executes each assertion
+  within a openEHR session.
+*/
+
+var openEHR = require('./../../lib/openEHR/openEHR');
+
+inOpenEHRSession = function(tests) {
+  Object.keys(openEHR.servers).forEach(function(server) {
+    var session;
+
+    // Create a session with the current openEHR server
+    beforeEach(function(done) {
+      openEHR.startSession(server, function(res) {
+        session = res.id;
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      openEHR.stopSession(server, session, done);
+    });
+
+    function request(url, data, done, process) {
+      openEHR.request({
+        url: url,
+        queryString: data,
+        host: server,
+        session: session,
+        processBody: process,
+        callback: done
+      });
+    }
+
+    tests(request, server);
+  });
+}

--- a/spec/helpers/session.js
+++ b/spec/helpers/session.js
@@ -37,14 +37,14 @@ inOpenEHRSession = function(tests) {
     var session;
 
     // Create a session with the current openEHR server
-    beforeEach(function(done) {
+    beforeAll(function(done) {
       openEHR.startSession(server, function(res) {
         session = res.id;
         done();
       });
     });
 
-    afterEach(function(done) {
+    afterAll(function(done) {
       openEHR.stopSession(server, session, done);
     });
 


### PR DESCRIPTION
# Field Mapping tests

I have adjusted the existing test suite such that it so that more assertions can be made upon a result from an openEHR call. This was done to check the mappings in the `fieldMaps` reference values which are returned back from the openEHR servers.

In the case of `string` mappings, this is pretty trivial (make an openEHR call and check that all string `fieldMaps` exist as keys in a response).

However the use of functions mappings is more involved. To test that the data is passing through correctly, we can add a *jasmine spy* on to the functions used within `dateTime` and assert that a value is always passed in.

## Problems Identified

Running the tests suite has identified 2 issues with the `fieldMappings` one in `mdtreports` and one in `laborders`. Both will have to be fixed in order for the test suite to pass.