### PR TITLE
Fix undefined Date on Vitals - NEWS page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# qewd-ripple
+#Ripple-Qewd .. a.k.a. qewd-ripple on npm
 
 [![Build Status](https://travis-ci.org/RippleOSI/Qewd-Ripple.svg?branch=master)](https://travis-ci.org/RippleOSI/Qewd-Ripple)
 
 
-Email: <code.custodian@rippleosi.org>
-2016 Ripple Foundation Community Interest Company [http://rippleosi.org  ](http://rippleosi.org)
+Email: <code.custodian@ripple.foundation>
+2016 Ripple Foundation Community Interest Company [http://ripple.foundation](http://ripple.foundation)
 
 Author: Rob Tweed, M/Gateway Developments Ltd (@rtweed)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Ripple-Qewd .. a.k.a. qewd-ripple on npm
+#Ripple-Qewd .. a.k.a. qewd-ripple
 
 [![Build Status](https://travis-ci.org/RippleOSI/Qewd-Ripple.svg?branch=master)](https://travis-ci.org/RippleOSI/Qewd-Ripple)
 
@@ -10,7 +10,7 @@ Author: Rob Tweed, M/Gateway Developments Ltd (@rtweed)
 
 ## Introduction
 
-*qewd-ripple* is a Node.js-based Middle Tier for the Ripple OSI project, based on the QEWD framework.
+*qewd-ripple* is a Node.js-based Middle Tier for the Ripple Foundation open source platform push, based on the [QEWDjs](http://qewdjs.com) framework.
 
 
 ### Installing and Configuring the RippleOSI Node.js / QEWD Middle Tier

--- a/lib/headings/vitalsigns.js
+++ b/lib/headings/vitalsigns.js
@@ -31,7 +31,7 @@
 var heading = {
   name: 'vitalsigns',
   textFieldName: 'author',
-  headingTableFields: ['author', 'dateCreate',  'newsScore', 'respirationRate', 'oxygenSupplemental', 
+  headingTableFields: ['author', 'dateCreated',  'newsScore', 'respirationRate', 'oxygenSupplemental', 
     'heartRate', 'temperature', 'levelOfConsciousness', 'systolicBP', 'diastolicBP', 'oxygenSaturation'],
 
   get: {


### PR DESCRIPTION
There is the undefined date on Vitals - NEWS page.

<img width="572" alt="screen shot 2017-06-02 at 4 11 01 pm" src="https://cloud.githubusercontent.com/assets/1429230/26719253/016dfdd2-47ae-11e7-8ca3-7ff3343e57dd.png">

This pull request fixed this issue.

Best Regards.
Nam Vu from ThinkLabs-VN