### PR TITLE
fixed bracketing around link

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Restart QEWD-Ripple using:
 
 ## About QEWD.js
 
-For further information on QEWD.js, see [http://qewdjs.com)
+For further information on QEWD.js, see http://qewdjs.com
 
 
 


### PR DESCRIPTION
I've assumed you want to display the full URL, in which case the brackets are not required. I've removed them